### PR TITLE
RM-44603 provider availability displays in wrong time slot

### DIFF
--- a/lib/DayColumn.js
+++ b/lib/DayColumn.js
@@ -220,11 +220,17 @@ var _initialiseProps = function _initialiseProps() {
         availabilityStartAccessor = _props2.availabilityStartAccessor,
         availabilityEndAccessor = _props2.availabilityEndAccessor,
         availabilityKeyAccessor = _props2.availabilityKeyAccessor,
-        min = _props2.min;
+        min = _props2.min,
+        step = _props2.step;
 
     var AvailabilityComponent = availabilityComponent;
     var styledAvailabilities = (0, _dayViewLayout.getStyledAvailabilities)({
-      availabilities: availabilities, availabilityStartAccessor: availabilityStartAccessor, availabilityEndAccessor: availabilityEndAccessor, min: min, totalMin: _this2._totalMin
+      availabilities: availabilities,
+      availabilityStartAccessor: availabilityStartAccessor,
+      availabilityEndAccessor: availabilityEndAccessor,
+      min: min,
+      step: step,
+      totalMin: _this2._totalMin
     });
 
     return styledAvailabilities.map(function (_ref, idx) {

--- a/lib/utils/dayViewLayout.js
+++ b/lib/utils/dayViewLayout.js
@@ -391,25 +391,24 @@ function getStyledAvailabilities(_ref8) {
       availabilityStartAccessor = _ref8.availabilityStartAccessor,
       availabilityEndAccessor = _ref8.availabilityEndAccessor,
       min = _ref8.min,
+      step = _ref8.step,
       totalMin = _ref8.totalMin;
 
   var styledAvailabilities = [];
 
   if (!availabilities) return styledAvailabilities;
 
-  availabilities.forEach(function (availability) {
-    var startTime = (0, _accessors.accessor)(availability, availabilityStartAccessor);
-    var start = positionFromDate(startTime, min, totalMin);
+  var helperArgs = {
+    events: availabilities,
+    startAccessor: availabilityStartAccessor,
+    endAccessor: availabilityEndAccessor,
+    min: min,
+    step: step,
+    totalMin: totalMin
+  };
 
-    var endTime = (0, _accessors.accessor)(availability, availabilityEndAccessor);
-    var end = positionFromDate(endTime, min, totalMin);
-
-    var top = start / totalMin * 100;
-    var bottom = end / totalMin * 100;
-    var height = bottom - top;
-
-    var style = { top: top, height: height };
-
+  availabilities.forEach(function (availability, availabilityIdx) {
+    var style = getYStyles(availabilityIdx, helperArgs);
     styledAvailabilities.push({ availability: availability, style: style });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elationhealth/react-big-calendar",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "description": "Calendar! with events",
   "author": "Jason Quense <monastic.panic@gmail.com>",
   "repository": "intljusticemission/react-big-calendar",

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -163,10 +163,16 @@ class DaySlot extends React.Component {
       availabilityEndAccessor,
       availabilityKeyAccessor,
       min,
+      step,
     } = this.props;
     const AvailabilityComponent = availabilityComponent;
     const styledAvailabilities = getStyledAvailabilities({
-      availabilities, availabilityStartAccessor, availabilityEndAccessor, min, totalMin: this._totalMin
+      availabilities,
+      availabilityStartAccessor,
+      availabilityEndAccessor,
+      min,
+      step,
+      totalMin: this._totalMin,
     });
 
     return styledAvailabilities.map(({availability, style}, idx) => {

--- a/src/utils/dayViewLayout.js
+++ b/src/utils/dayViewLayout.js
@@ -335,25 +335,28 @@ export default function getStyledEvents ({
  *
  */
 export function getStyledAvailabilities ({
-  availabilities, availabilityStartAccessor, availabilityEndAccessor, min, totalMin
+  availabilities,
+  availabilityStartAccessor,
+  availabilityEndAccessor,
+  min,
+  step,
+  totalMin,
 }) {
   let styledAvailabilities = [];
 
   if (!availabilities) return styledAvailabilities;
 
-  availabilities.forEach((availability) => {
-    const startTime = get(availability, availabilityStartAccessor);
-    const start = positionFromDate(startTime, min, totalMin);
+  const helperArgs = {
+    events: availabilities,
+    startAccessor: availabilityStartAccessor,
+    endAccessor: availabilityEndAccessor,
+    min,
+    step,
+    totalMin,
+  };
 
-    const endTime = get(availability, availabilityEndAccessor);
-    const end = positionFromDate(endTime, min, totalMin);
-
-    const top = (start / totalMin) * 100;
-    const bottom = (end / totalMin) * 100;
-    const height = bottom - top;
-
-    const style = { top, height };
-
+  availabilities.forEach((availability, availabilityIdx) => {
+    let style = getYStyles(availabilityIdx, helperArgs);
     styledAvailabilities.push({ availability, style });
   })
 


### PR DESCRIPTION
Changes included in this pull request:
- Update getStyledAvailabilities to display availabilities correctly on fall time change
- Bump PATCH version

Fixes JIRA issues:
- Ticket: [RM-44603](https://elationhealth.atlassian.net/browse/RM-44603)

Before Fix:

![Screenshot 2023-10-23 at 6 56 26 PM](https://github.com/elationemr/react-big-calendar/assets/18340986/bd0abdb5-6c44-4a40-8b1e-d598a6091d01)

After Fix:

![Screenshot 2023-10-23 at 6 58 28 PM](https://github.com/elationemr/react-big-calendar/assets/18340986/690321a4-1d1a-4e9b-952f-cbf66fba2e95)

[RM-44603]: https://elationhealth.atlassian.net/browse/RM-44603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ