### PR TITLE
Fix spring-forward event positioning misalignment with time gutter

### DIFF
--- a/lib/MultiTimeGrid.js
+++ b/lib/MultiTimeGrid.js
@@ -207,7 +207,7 @@ var MultiTimeGrid = function (_Component) {
               } },
             _react2.default.createElement(_TimeColumn2.default, _extends({}, this.props, {
               min: _dates2.default.merge(date, this.props.min),
-              max: _dates2.default.merge(date, this.props.max),
+              max: new Date(_dates2.default.merge(date, this.props.min).getTime() + 24 * 60 * 60 * 1000),
               showLabels: true,
               ref: gutterRef,
               className: 'rbc-time-gutter'
@@ -251,9 +251,10 @@ var MultiTimeGrid = function (_Component) {
       var availabilities = availabilityMap && availabilityMap[selectedEntityKey] || [];
       var daysAvailabilities = availabilities.filter((0, _helpers.makeEventOrAvailabilityFilter)(date, availabilityStartAccessor, availabilityEndAccessor));
 
+      var dayMin = _dates2.default.merge(date, min);
       return _react2.default.createElement(_DayColumn2.default, _extends({}, _this3.props, {
-        min: _dates2.default.merge(date, min),
-        max: _dates2.default.merge(date, max),
+        min: dayMin,
+        max: new Date(dayMin.getTime() + 24 * 60 * 60 * 1000),
         availabilityComponent: components.availability,
         availabilityWrapperComponent: components.availabilityWrapper,
         availabilities: daysAvailabilities,

--- a/lib/TimeGrid.js
+++ b/lib/TimeGrid.js
@@ -179,7 +179,7 @@ var TimeGrid = function (_Component) {
         _react2.default.createElement('div', { style: { display: 'none' } }),
         _react2.default.createElement(_TimeColumn2.default, _extends({}, this.props, {
           min: _dates2.default.merge(start, this.props.min),
-          max: _dates2.default.merge(start, this.props.max),
+          max: new Date(_dates2.default.merge(start, this.props.min).getTime() + 24 * 60 * 60 * 1000),
           showLabels: true,
           style: { width: width },
           ref: gutterRef,

--- a/lib/utils/dayViewLayout.js
+++ b/lib/utils/dayViewLayout.js
@@ -62,12 +62,14 @@ var getSlot = function getSlot(event, accessor, min, totalMin) {
 
   var time = (0, _accessors.accessor)(event, accessor);
 
-  // Use the offset at the event's actual time (DST can change during the day).
+  // On fall-back DST days, the number of calendar slots doesn't match
+  // the number of hours in that day (we don't show two slots for the
+  // two 1AMs that exist). Adjust post-transition times so positions
+  // reflect practical elapsed hours rather than real elapsed hours.
   var dayStart = _dates2.default.startOf(time, 'day');
   var dayEnd = _dates2.default.endOf(time, 'day');
   var daylightSavingsShift = dayStart.getTimezoneOffset() - dayEnd.getTimezoneOffset();
   var isFallingBack = daylightSavingsShift < 0;
-  var isSpringingForward = daylightSavingsShift > 0;
   if (isFallingBack && time.getTimezoneOffset() !== dayStart.getTimezoneOffset()) {
     time = _dates2.default.add(time, daylightSavingsShift, 'minutes');
   }
@@ -93,15 +95,7 @@ var getSlot = function getSlot(event, accessor, min, totalMin) {
       time = new Date(min);
     }
   }
-  var pos = event && positionFromDate(time, min, totalMin);
-  // positionFromDate uses merge(min, time) which injects wall-clock hours but measures
-  // real milliseconds from dayMin. On spring-forward days the 1-hour DST gap means a
-  // post-transition event (e.g. 10am PDT) is only 9 UTC hours from midnight PST, so it
-  // lands at the 9am slot. Add the DST shift (60 min) to re-align with the wall clock.
-  if (typeof pos === 'number' && isSpringingForward && time.getTimezoneOffset() !== dayStart.getTimezoneOffset()) {
-    pos = Math.min(pos + 60, totalMin);
-  }
-  return pos;
+  return event && positionFromDate(time, min, totalMin);
 };
 
 /**

--- a/src/MultiTimeGrid.js
+++ b/src/MultiTimeGrid.js
@@ -204,7 +204,7 @@ export default class MultiTimeGrid extends Component {
               <TimeColumn
                 {...this.props}
                 min={dates.merge(date, this.props.min)}
-                max={dates.merge(date, this.props.max)}
+                max={new Date(dates.merge(date, this.props.min).getTime() + 24 * 60 * 60 * 1000)}
                 showLabels
                 ref={gutterRef}
                 className='rbc-time-gutter'
@@ -248,11 +248,12 @@ export default class MultiTimeGrid extends Component {
         makeEventOrAvailabilityFilter(date, availabilityStartAccessor, availabilityEndAccessor)
       );
 
+      const dayMin = dates.merge(date, min);
       return (
         <DayColumn
           {...this.props }
-          min={dates.merge(date, min)}
-          max={dates.merge(date, max)}
+          min={dayMin}
+          max={new Date(dayMin.getTime() + 24 * 60 * 60 * 1000)}
           availabilityComponent={components.availability}
           availabilityWrapperComponent={components.availabilityWrapper}
           availabilities={daysAvailabilities}

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -179,7 +179,7 @@ export default class TimeGrid extends Component {
           <TimeColumn
             {...this.props}
             min={dates.merge(start, this.props.min)}
-            max={dates.merge(start, this.props.max)}
+            max={new Date(dates.merge(start, this.props.min).getTime() + 24 * 60 * 60 * 1000)}
             showLabels
             style={{ width }}
             ref={gutterRef}

--- a/src/utils/dayViewLayout.js
+++ b/src/utils/dayViewLayout.js
@@ -43,13 +43,15 @@ let getSlot = (event, accessor, min, totalMin, isEndAccessor = false) => {
 
   let time = get(event, accessor);
 
-  // Use the offset at the event's actual time (DST can change during the day).
+  // On fall-back DST days, the number of calendar slots doesn't match
+  // the number of hours in that day (we don't show two slots for the
+  // two 1AMs that exist). Adjust post-transition times so positions
+  // reflect practical elapsed hours rather than real elapsed hours.
   const dayStart = dates.startOf(time, 'day');
   const dayEnd = dates.endOf(time, 'day');
   const daylightSavingsShift =
     dayStart.getTimezoneOffset() - dayEnd.getTimezoneOffset();
   const isFallingBack = daylightSavingsShift < 0;
-  const isSpringingForward = daylightSavingsShift > 0;
   if (isFallingBack && time.getTimezoneOffset() !== dayStart.getTimezoneOffset()) {
     time = dates.add(time, daylightSavingsShift, 'minutes');
   }
@@ -75,15 +77,7 @@ let getSlot = (event, accessor, min, totalMin, isEndAccessor = false) => {
       time = new Date(min);
     }
   }
-  let pos = event && positionFromDate(time, min, totalMin);
-  // positionFromDate uses merge(min, time) which injects wall-clock hours but measures
-  // real milliseconds from dayMin. On spring-forward days the 1-hour DST gap means a
-  // post-transition event (e.g. 10am PDT) is only 9 UTC hours from midnight PST, so it
-  // lands at the 9am slot. Add the DST shift (60 min) to re-align with the wall clock.
-  if (typeof pos === 'number' && isSpringingForward && time.getTimezoneOffset() !== dayStart.getTimezoneOffset()) {
-    pos = Math.min(pos + 60, totalMin);
-  }
-  return pos;
+  return event && positionFromDate(time, min, totalMin);
 }
 
 /**


### PR DESCRIPTION
## Summary

The v0.13.15 spring-forward fix (PR #24) introduced a `+60` minute position adjustment for post-DST events in `dayViewLayout.getSlot`. This causes events to display **one hour off** from their time gutter labels on spring-forward days (e.g., March 8).

**Root cause**: The `DayColumn` (events) and `TimeColumn` (gutter) use different `totalMin` values on spring-forward days:
- `DayColumn`: `totalMin = 1440` (from `dayMin + 24h`), events positioned at `(realMinutes + 60) / 1440`
- `TimeColumn` (gutter): `totalMin ≈ 1380` (23 real hours), labels at `groupIndex / 23`

A 10am event appears at `600/1440 = 41.7%` but the 10am gutter label is at `9/23 = 39.1%` — a ~2.5% gap = ~1 hour visual offset.

**Fix**:
1. **Remove** the `+60` spring-forward adjustment from `getSlot` — it's not needed when gutter and events both use real-time positioning
2. **Update** the `TimeColumn` gutter in `TimeGrid` to also use `dayMin + 24h` as `max`, matching the `DayColumn`

With both using `totalMin = 1440`, real-time event positions naturally align with gutter groups (which skip 2AM→3AM via `dates.add` on spring-forward days). The existing fall-back adjustment is preserved.

## Test plan

- [ ] Verify events align with time labels on spring-forward day (March 8)
- [ ] Verify events align with time labels on normal (non-DST) days
- [ ] Verify events align with time labels on fall-back day (November)
- [ ] Test in both Day view and Week view


Made with [Cursor](https://cursor.com)