### PR TITLE
Use wall-clock positioning for DST-correct event alignment

### DIFF
--- a/lib/MultiTimeGrid.js
+++ b/lib/MultiTimeGrid.js
@@ -207,7 +207,7 @@ var MultiTimeGrid = function (_Component) {
               } },
             _react2.default.createElement(_TimeColumn2.default, _extends({}, this.props, {
               min: _dates2.default.merge(date, this.props.min),
-              max: _dates2.default.merge(date, this.props.max),
+              max: new Date(_dates2.default.merge(date, this.props.min).getTime() + 24 * 60 * 60 * 1000),
               showLabels: true,
               ref: gutterRef,
               className: 'rbc-time-gutter'
@@ -251,9 +251,10 @@ var MultiTimeGrid = function (_Component) {
       var availabilities = availabilityMap && availabilityMap[selectedEntityKey] || [];
       var daysAvailabilities = availabilities.filter((0, _helpers.makeEventOrAvailabilityFilter)(date, availabilityStartAccessor, availabilityEndAccessor));
 
+      var dayMin = _dates2.default.merge(date, min);
       return _react2.default.createElement(_DayColumn2.default, _extends({}, _this3.props, {
-        min: _dates2.default.merge(date, min),
-        max: _dates2.default.merge(date, max),
+        min: dayMin,
+        max: new Date(dayMin.getTime() + 24 * 60 * 60 * 1000),
         availabilityComponent: components.availability,
         availabilityWrapperComponent: components.availabilityWrapper,
         availabilities: daysAvailabilities,

--- a/lib/TimeColumn.js
+++ b/lib/TimeColumn.js
@@ -175,11 +175,15 @@ var TimeColumn = function (_Component) {
     var next = date;
     var isNow = false;
 
+    var useWallClock = this.props.showLabels;
+    var refDate = useWallClock ? new Date(min.getFullYear(), 0, 1, _dates2.default.hours(min), _dates2.default.minutes(min)) : null;
+
     for (var i = 0; i < numGroups; i++) {
       isNow = _dates2.default.inRange(now, date, _dates2.default.add(next, groupLengthInMinutes - 1, 'minutes'), 'minutes');
 
+      var slotDate = useWallClock ? _dates2.default.add(refDate, i * groupLengthInMinutes, 'minutes') : date;
       next = _dates2.default.add(date, groupLengthInMinutes, 'minutes');
-      renderedSlots.push(this.renderTimeSliceGroup(i, isNow, date));
+      renderedSlots.push(this.renderTimeSliceGroup(i, isNow, slotDate));
 
       date = next;
     }

--- a/lib/TimeGrid.js
+++ b/lib/TimeGrid.js
@@ -179,7 +179,7 @@ var TimeGrid = function (_Component) {
         _react2.default.createElement('div', { style: { display: 'none' } }),
         _react2.default.createElement(_TimeColumn2.default, _extends({}, this.props, {
           min: _dates2.default.merge(start, this.props.min),
-          max: _dates2.default.merge(start, this.props.max),
+          max: new Date(_dates2.default.merge(start, this.props.min).getTime() + 24 * 60 * 60 * 1000),
           showLabels: true,
           style: { width: width },
           ref: gutterRef,

--- a/lib/utils/dayViewLayout.js
+++ b/lib/utils/dayViewLayout.js
@@ -21,8 +21,10 @@ function startsBefore(date, min) {
 function positionFromDate(date, min, total) {
   if (startsBefore(date, min)) return 0;
 
-  var diff = _dates2.default.diff(min, _dates2.default.merge(min, date), 'minutes');
-  return Math.min(diff, total);
+  var merged = _dates2.default.merge(min, date);
+  var wallMinutes = (_dates2.default.hours(merged) - _dates2.default.hours(min)) * 60 + (_dates2.default.minutes(merged) - _dates2.default.minutes(min));
+  if (wallMinutes < 0) wallMinutes += 24 * 60;
+  return Math.min(wallMinutes, total);
 }
 
 /**
@@ -62,16 +64,6 @@ var getSlot = function getSlot(event, accessor, min, totalMin) {
 
   var time = (0, _accessors.accessor)(event, accessor);
 
-  // Use the offset at the event's actual time (DST can change during the day).
-  var dayStart = _dates2.default.startOf(time, 'day');
-  var dayEnd = _dates2.default.endOf(time, 'day');
-  var daylightSavingsShift = dayStart.getTimezoneOffset() - dayEnd.getTimezoneOffset();
-  var isFallingBack = daylightSavingsShift < 0;
-  var isSpringingForward = daylightSavingsShift > 0;
-  if (isFallingBack && time.getTimezoneOffset() !== dayStart.getTimezoneOffset()) {
-    time = _dates2.default.add(time, daylightSavingsShift, 'minutes');
-  }
-
   // Handling long range events. Though long range events have a condition that
   // start and end times are less than 24 hours apart, we don't perform that check
   // here. That should already be handled at the TimeGrid/MultiTimeGrid level, and
@@ -93,15 +85,7 @@ var getSlot = function getSlot(event, accessor, min, totalMin) {
       time = new Date(min);
     }
   }
-  var pos = event && positionFromDate(time, min, totalMin);
-  // positionFromDate uses merge(min, time) which injects wall-clock hours but measures
-  // real milliseconds from dayMin. On spring-forward days the 1-hour DST gap means a
-  // post-transition event (e.g. 10am PDT) is only 9 UTC hours from midnight PST, so it
-  // lands at the 9am slot. Add the DST shift (60 min) to re-align with the wall clock.
-  if (typeof pos === 'number' && isSpringingForward && time.getTimezoneOffset() !== dayStart.getTimezoneOffset()) {
-    pos = Math.min(pos + 60, totalMin);
-  }
-  return pos;
+  return event && positionFromDate(time, min, totalMin);
 };
 
 /**

--- a/src/MultiTimeGrid.js
+++ b/src/MultiTimeGrid.js
@@ -204,7 +204,7 @@ export default class MultiTimeGrid extends Component {
               <TimeColumn
                 {...this.props}
                 min={dates.merge(date, this.props.min)}
-                max={dates.merge(date, this.props.max)}
+                max={new Date(dates.merge(date, this.props.min).getTime() + 24 * 60 * 60 * 1000)}
                 showLabels
                 ref={gutterRef}
                 className='rbc-time-gutter'
@@ -248,11 +248,12 @@ export default class MultiTimeGrid extends Component {
         makeEventOrAvailabilityFilter(date, availabilityStartAccessor, availabilityEndAccessor)
       );
 
+      const dayMin = dates.merge(date, min);
       return (
         <DayColumn
           {...this.props }
-          min={dates.merge(date, min)}
-          max={dates.merge(date, max)}
+          min={dayMin}
+          max={new Date(dayMin.getTime() + 24 * 60 * 60 * 1000)}
           availabilityComponent={components.availability}
           availabilityWrapperComponent={components.availabilityWrapper}
           availabilities={daysAvailabilities}

--- a/src/TimeColumn.js
+++ b/src/TimeColumn.js
@@ -104,6 +104,11 @@ export default class TimeColumn extends Component {
     let next = date
     let isNow = false
 
+    const useWallClock = this.props.showLabels
+    const refDate = useWallClock
+      ? new Date(min.getFullYear(), 0, 1, dates.hours(min), dates.minutes(min))
+      : null
+
     for (var i = 0; i < numGroups; i++) {
       isNow = dates.inRange(
           now
@@ -112,8 +117,11 @@ export default class TimeColumn extends Component {
         , 'minutes'
       )
 
+      const slotDate = useWallClock
+        ? dates.add(refDate, i * groupLengthInMinutes, 'minutes')
+        : date
       next = dates.add(date, groupLengthInMinutes, 'minutes');
-      renderedSlots.push(this.renderTimeSliceGroup(i, isNow, date))
+      renderedSlots.push(this.renderTimeSliceGroup(i, isNow, slotDate))
 
       date = next
     }

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -179,7 +179,7 @@ export default class TimeGrid extends Component {
           <TimeColumn
             {...this.props}
             min={dates.merge(start, this.props.min)}
-            max={dates.merge(start, this.props.max)}
+            max={new Date(dates.merge(start, this.props.min).getTime() + 24 * 60 * 60 * 1000)}
             showLabels
             style={{ width }}
             ref={gutterRef}

--- a/src/utils/dayViewLayout.js
+++ b/src/utils/dayViewLayout.js
@@ -9,8 +9,11 @@ export function positionFromDate(date, min, total) {
   if (startsBefore(date, min))
     return 0
 
-  let diff = dates.diff(min, dates.merge(min, date), 'minutes')
-  return Math.min(diff, total)
+  const merged = dates.merge(min, date)
+  let wallMinutes = (dates.hours(merged) - dates.hours(min)) * 60
+    + (dates.minutes(merged) - dates.minutes(min))
+  if (wallMinutes < 0) wallMinutes += 24 * 60
+  return Math.min(wallMinutes, total)
 }
 
 /**
@@ -43,17 +46,6 @@ let getSlot = (event, accessor, min, totalMin, isEndAccessor = false) => {
 
   let time = get(event, accessor);
 
-  // Use the offset at the event's actual time (DST can change during the day).
-  const dayStart = dates.startOf(time, 'day');
-  const dayEnd = dates.endOf(time, 'day');
-  const daylightSavingsShift =
-    dayStart.getTimezoneOffset() - dayEnd.getTimezoneOffset();
-  const isFallingBack = daylightSavingsShift < 0;
-  const isSpringingForward = daylightSavingsShift > 0;
-  if (isFallingBack && time.getTimezoneOffset() !== dayStart.getTimezoneOffset()) {
-    time = dates.add(time, daylightSavingsShift, 'minutes');
-  }
-
   // Handling long range events. Though long range events have a condition that
   // start and end times are less than 24 hours apart, we don't perform that check
   // here. That should already be handled at the TimeGrid/MultiTimeGrid level, and
@@ -75,15 +67,7 @@ let getSlot = (event, accessor, min, totalMin, isEndAccessor = false) => {
       time = new Date(min);
     }
   }
-  let pos = event && positionFromDate(time, min, totalMin);
-  // positionFromDate uses merge(min, time) which injects wall-clock hours but measures
-  // real milliseconds from dayMin. On spring-forward days the 1-hour DST gap means a
-  // post-transition event (e.g. 10am PDT) is only 9 UTC hours from midnight PST, so it
-  // lands at the 9am slot. Add the DST shift (60 min) to re-align with the wall clock.
-  if (typeof pos === 'number' && isSpringingForward && time.getTimezoneOffset() !== dayStart.getTimezoneOffset()) {
-    pos = Math.min(pos + 60, totalMin);
-  }
-  return pos;
+  return event && positionFromDate(time, min, totalMin);
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces the previous approach of using `dates.diff` (real elapsed milliseconds) plus per-case DST adjustments (`+60` for spring-forward, `-60` for fall-back) with wall-clock positioning that naturally handles all DST transitions.

### Problem

In the Week view, the time gutter is based on the first day of the week (a non-DST day), but event positions on the spring-forward day (March 8) were computed using real elapsed time. Since noon on March 8 is only 11 real hours from midnight (the spring-forward missing hour), events appeared at the 11 AM position instead of noon.

The previous `+60` fix (PR #24) corrected the Week view but broke the Day view on March 8, because both the gutter and events are on the same DST day — adding `+60` shifted events relative to the gutter.

### Solution

- **`positionFromDate`**: Uses `dates.hours()` and `dates.minutes()` (wall-clock) instead of `dates.diff` (real elapsed milliseconds). Noon is always at position 720/1440 = 50% regardless of DST.
- **`getSlot`**: Removed all DST adjustments (both spring-forward and fall-back). Wall-clock positioning handles both naturally.
- **`TimeColumn`**: Gutter labels (`showLabels: true`) use a non-DST reference date (Jan 1) for iteration so noon is always at group 12. DayColumn slots keep their real dates to preserve `slotPropGetter` and availability styling.
- **`TimeGrid` / `MultiTimeGrid`**: Gutter `max` uses `dayMin + 24h` for consistent `totalMin` (1440) across all views.

### Views fixed

- Week view: March 8 noon event aligns with gutter "12 PM" label
- Day view on March 8: same alignment
- Multi-physician view: same fix applies (uses same TimeColumn and positionFromDate)

### Tagged as v0.13.17


Made with [Cursor](https://cursor.com)